### PR TITLE
improve WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,9 +11,8 @@ http_archive(
 # ===== gtest =====
 new_http_archive(
     name = "com_google_googletest",
-    url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
-    sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
-    strip_prefix = "googletest-release-1.8.0",
+    url = "https://github.com/google/googletest/archive/master.zip",
+    strip_prefix = "googletest-master",
     build_file_content = """
 licenses(["notice"])
 


### PR DESCRIPTION
During testing, the following issue was reported
"
[235 / 251] Compiling external/com_google_protobuf/src/google/protobuf/descriptor.pb.cc [for host]; 2s linux-sandbox ... (7 actions running)
[289 / 298] Compiling cudnn_conv_test.cc; 0s linux-sandbox ... (7 actions running)
ERROR: .../cuda/_tests/google_cudnn_test/codes/nvidia_libs_test-master/BUILD:110:1: C++ compilation of rule '//:cudnn_test' failed (Exit 1) gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 103 argument(s) skipped)
Use --sandbox_debug to see verbose messages from the sandbox
cudnn_conv_test.cc:1203:25: error: expected constructor, destructor, or type conversion before '(' token
INSTANTIATE_TEST_SUITE_P(
^
cudnn_conv_test.cc:1208:25: error: expected constructor, destructor, or type conversion before '(' token
INSTANTIATE_TEST_SUITE_P(Conv2dFilter3x3, ConvolutionTest,
^
cudnn_conv_test.cc:1242:1: error: expected '}' at end of input
} // namespace nvidia_libs_test
^
cudnn_conv_test.cc:1242:1: error: expected '}' at end of input
cudnn_conv_test.cc: In function 'double nvidia_libs_test::{anonymous}::GetToleranceScale(const nvidia_libs_test::proto::ConvolutionConfig&)':
cudnn_conv_test.cc:148:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
"

Since INSTANTIATE_TEST_SUITE_P can be supported by master branch, I created this request for approval.

Thanks
Bo